### PR TITLE
sync zoom between maptalks and ecgl

### DIFF
--- a/src/component/maptalks3D/Maptalks3DView.js
+++ b/src/component/maptalks3D/Maptalks3DView.js
@@ -134,7 +134,7 @@ export default echarts.extendComponentView({
         api.dispatchAction({
             type: 'maptalks3DChangeCamera',
             pitch: maptalks.getPitch(),
-            zoom: maptalks.getZoom(),
+            zoom: getMapboxZoom(maptalks.getResolution()) + 1,
             center: maptalks.getCenter().toArray(),
             bearing: maptalks.getBearing(),
             maptalks3DId: this._maptalks3DModel && this._maptalks3DModel.id
@@ -164,3 +164,8 @@ export default echarts.extendComponentView({
         api.getZr().painter.delLayer(-1000);
     }
 });
+
+const MAX_RES = 2 * 6378137 * Math.PI / (256 * Math.pow(2, 20));
+function getMapboxZoom(res) {
+    return 19 - Math.log(res / MAX_RES) / Math.LN2;
+}


### PR DESCRIPTION
## 错误描述
地图zoom为小数形式时，例如16.5时，maptalks会与ecgl图形出现偏离， 如图：
![image](https://user-images.githubusercontent.com/13678919/49861548-0d9f4c00-fe37-11e8-9f69-09711dff9417.png)
这个bug造成的另外一个现象是缩放过程中，ecgl图形会出现摇摆

## 重现链接
http://gallery.echartsjs.com/editor.html?c=xNWIxFpSdR&v=2
示例中左下角的图形偏离比较明显

## 原因
ecgl是基于mapbox的算法来计算zoom的，maptalks中的zoom和mapbox的zoom同步存在bug，这个pr解决了这个问题。