### PR TITLE
fix(globe/geo): don't fix `scale's` min and max

### DIFF
--- a/src/coord/geo3DCreator.js
+++ b/src/coord/geo3DCreator.js
@@ -78,9 +78,6 @@ function updateGeo3D(ecModel, api) {
         var scale = echarts.helper.createScale(
             altitudeDataExtent, {
                 type: 'value',
-                // PENDING
-                min: 'dataMin',
-                max: 'dataMax'
             }
         );
         this.altitudeAxis = new echarts.Axis('altitude', scale);

--- a/src/coord/globeCreator.js
+++ b/src/coord/globeCreator.js
@@ -78,9 +78,6 @@ function updateGlobe(ecModel, api) {
         var scale = echarts.helper.createScale(
             altitudeDataExtent, {
                 type: 'value',
-                // PENDING
-                min: 'dataMin',
-                max: 'dataMax'
             }
         );
         this.altitudeAxis = new echarts.Axis('altitude', scale);


### PR DESCRIPTION
- Close #432

specify `dataMin` to create `scale` would make the`dir` to 0, which makes this value disappear