### PR TITLE
Shared WebGL-context implementation to partially fix ecomfe/echarts-gl#439

### DIFF
--- a/src/chart/flowGL/FlowGLView.js
+++ b/src/chart/flowGL/FlowGLView.js
@@ -64,6 +64,9 @@ export default echarts.ChartView.extend({
                 __percent: 1
             })
             .during(function () {
+                if (self._renderer && self._renderer.gl.isContextLost()) {
+                    self._renderer = self._layerGL.renderer;
+                }
                 var timeNow = + (new Date());
                 var dTime = Math.min(timeNow - time, 20);
                 time = time + dTime;
@@ -94,6 +97,7 @@ export default echarts.ChartView.extend({
     afterRender: function (globeModel, ecModel, api, layerGL) {
         var renderer = layerGL.renderer;
         this._renderer = renderer;
+        this._layerGL = layerGL;
     },
 
     _updateData: function (seriesModel, api) {

--- a/src/core/LayerGL.js
+++ b/src/core/LayerGL.js
@@ -283,12 +283,17 @@ LayerGL.prototype.renderToCanvas = function (ctx) {
 
 LayerGL.prototype._doRender = function (accumulating) {
     if (this.renderer.gl.isContextLost()) {
-        console.log('context lost, resetting renderer')
+        console.log('context lost, resetting renderer and refreshing')
         this.resetRenderer();
+
+        // Context lost in the "middle" of rendering/accumulating; trigger full rerender
+        this.needsRefresh();
+        return;
     }
 
     // Needed in case we are not directly called from render()
     this.renderer.clearColor = this._backgroundColor;
+    this.renderer.resize(this.zr.painter.getWidth(), this.zr.painter.getHeight());
 
     this.clear();
     this.renderer.saveViewport();

--- a/src/core/LayerGL.js
+++ b/src/core/LayerGL.js
@@ -282,6 +282,14 @@ LayerGL.prototype.renderToCanvas = function (ctx) {
 };
 
 LayerGL.prototype._doRender = function (accumulating) {
+    if (this.renderer.gl.isContextLost()) {
+        console.log('context lost, resetting renderer')
+        this.resetRenderer();
+    }
+
+    // Needed in case we are not directly called from render()
+    this.renderer.clearColor = this._backgroundColor;
+
     this.clear();
     this.renderer.saveViewport();
     for (var i = 0; i < this.views.length; i++) {

--- a/test/multi.html
+++ b/test/multi.html
@@ -1,0 +1,413 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Multiple plots - ECHARTS-GL</title>
+        <script src="../node_modules/echarts/dist/echarts.js"></script>
+        <script src="../dist/echarts-gl.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/simplex.js"></script>
+    </head>
+    <body>
+        <div id="ui">
+            <input type="text" id="width" value="400"> x <input type="text" id="height" value="400">
+            <button onclick="resize_plots();">Resize</button>
+            <button onclick="trigger_context_lost();">Trigger context lost</button>
+        </div>
+        <div id="plots"></div>
+        <script>
+
+            function trigger_context_lost() {
+                Array.from(Array(16), () => document.createElement('canvas').getContext('webgl'));
+            }
+
+
+
+            function create_flow_plot(div) {
+                var chart = echarts.init(div);
+
+                var noise = new SimplexNoise(Math.random);
+                var noise2 = new SimplexNoise(Math.random);
+                function generateData() {
+                    var data = [];
+                    for (var i = 0; i <= 50; i++) {
+                        for (var j = 0; j <= 50; j++) {
+                            var dx = noise.noise2D(i / 30, j / 30);
+                            var dy = noise2.noise2D(i / 30, j / 30);
+                            var mag = Math.sqrt(dx * dx + dy * dy);
+                            valMax = Math.max(valMax, mag);
+                            valMin = Math.min(valMin, mag);
+                            data.push([i, j, dx, dy, mag]);
+                        }
+                    }
+                    return data;
+                }
+                var valMin = Infinity;
+                var valMax = -Infinity;
+                var data = generateData();
+
+                chart.setOption({
+                    visualMap: {
+                        show: false,
+                        min: valMin,
+                        max: valMax,
+                        dimension: 4,
+                        inRange: {
+                            color: ['#313695', '#4575b4', '#74add1', '#abd9e9', '#e0f3f8', '#ffffbf', '#fee090', '#fdae61', '#f46d43', '#d73027', '#a50026']
+                        }
+                    },
+                    xAxis: {
+                        type: 'value',
+                        axisLine: {
+                            lineStyle: {
+                                color: '#000'
+                            }
+                        },
+                        splitLine: {
+                            show: false,
+                            lineStyle: {
+                                color: 'rgba(0,0,0,0.2)'
+                            }
+                        }
+                    },
+                    yAxis: {
+                        type: 'value',
+                        axisLine: {
+                            lineStyle: {
+                                color: '#000'
+                            }
+                        },
+                        splitLine: {
+                            show: false,
+                            lineStyle: {
+                                color: 'rgba(0,0,0,0.2)'
+                            }
+                        }
+                    },
+                    series: [{
+                        type: 'flowGL',
+                        data: data,
+                        particleDensity: 64,
+                        particleSize: 5,
+                        itemStyle: {
+                            opacity: 0.5
+                        }
+                    }, {
+                        type: 'custom',
+                        data: data,
+                        encode: {
+                            x: 0,
+                            y: 0
+                        },
+                        renderItem: function (params, api) {
+                            var x = api.value(0), y = api.value(1), dx = api.value(2), dy = api.value(3);
+                            var start = api.coord([x - dx / 2, y - dy / 2]);
+                            var end = api.coord([x + dx / 2, y + dy / 2]);
+                            return {
+                                type: 'line',
+                                shape: {
+                                    x1: start[0], y1: start[1],
+                                    x2: end[0], y2: end[1]
+                                },
+                                style: {
+                                    lineWidth: 2,
+                                    stroke:'#000'
+                                }
+                            }
+                        }
+                    }]
+                });
+
+                return chart;
+            }
+
+
+
+            function create_scatter_plot(div) {
+                var chart = echarts.init(div);
+                $.getJSON('data/masterPainterColorChoice.json', function (json) {
+
+                    var data = json[0].x.map(function (x, idx) {
+                        return [+x, +json[0].y[idx]];
+                    });
+
+                    chart.setOption({
+                        backgroundColor: '#fff',
+                        title: {
+                            text: 'Master Painter Color Choices Throughout History',
+                            subtext: 'Data From Plot.ly',
+                            x: 'right'
+                        },
+                        tooltip: {
+                            trigger: 'axis',
+                            axisPointer: {
+                                type: 'cross'
+                            }
+                        },
+                        xAxis: {
+                            type: 'value',
+                            splitLine: {
+                                show: false
+                            },
+                            scale: true,
+                            splitNumber: 5,
+                            axisLabel: {
+                                formatter: function (val) {
+                                    return val + 's';
+                                }
+                            }
+                        },
+                        yAxis: {
+                            type: 'value',
+                            min: 0,
+                            max: 360,
+                            splitNumber: 6,
+                            name: 'Hue',
+                            splitLine: {
+                                show: false
+                            }
+                        },
+                        series: [{
+                            type: 'scatterGL',
+                            symbolSize: function (val, param) {
+                                return json[0].marker.size[param.dataIndex] / json[0].marker.sizeref;
+                            },
+                            itemStyle: {
+                                opacity: 0.5,
+                                borderColor: '#000',
+                                borderWidth: 1,
+                                color: function (param) {
+                                    return json[0].marker.color[param.dataIndex];
+                                }
+                            },
+                            data: data
+                        }]
+                    });
+                });
+
+                return chart;
+            }
+
+
+
+            function create_surface_plot(div) {
+                var chart = echarts.init(div);
+
+                chart.setOption({
+                    backgroundColor: '#fff',
+                    xAxis3D: {},
+                    yAxis3D: {},
+                    zAxis3D: {},
+                    grid3D: {
+                        light: {
+                            main: {
+                                intensity: 0.7,
+                                shadow: true
+                            }
+                        },
+                        viewControl: {
+                        }
+                    },
+                    series: [{
+                        type: 'surface',
+                        shading: 'lambert',
+                        lambertMaterial: {
+                            detailTexture: 'asset/woods.jpg',
+                            // textureTiling: 4
+                        },
+                        wireframe: {
+                            show: true
+                        },
+                        itemStyle: {
+                            color: '#fff'
+                        },
+                        equation: {
+                            x: {
+                                step: 0.05
+                            },
+                            y: {
+                                step: 0.05
+                            },
+                            z: function (x, y) {
+                                if (Math.abs(x) < 0.1 && Math.abs(y) < 0.1) {
+                                    return '-';
+                                }
+                                return Math.sin(x * Math.PI) * Math.sin(y * Math.PI);
+                            }
+                        }
+                    }]
+                });
+
+                return chart;
+            }
+
+
+
+            function create_metal_plot(div) {
+                var chart = echarts.init(div);
+
+                var sin = Math.sin;
+                var cos = Math.cos;
+                var pow = Math.pow;
+                var sqrt = Math.sqrt;
+                var cosh = Math.cosh;
+                var sinh = Math.sinh;
+                var PI = Math.PI;
+
+                var aa = 0.4;
+                var r = 1 - aa * aa;
+                var w = sqrt(r);
+
+                var config = {
+                    aa: aa
+                };
+
+                function getParametricEquation() {
+                    return {
+                        u: {
+                            min: -13.2,
+                            max: 13.2,
+                            step: 0.4
+                        },
+                        v: {
+                            min: -37.4,
+                            max: 37.4,
+                            step: 0.4
+                        },
+                        x: function (u, v) {
+                            var denom = aa * (pow(w * cosh(aa * u), 2) + aa * pow(sin(w * v), 2))
+                            return -u + (2 * r * cosh(aa * u) * sinh(aa * u) / denom);
+                        },
+                        y: function (u, v) {
+                            var denom = aa * (pow(w * cosh(aa * u), 2) + aa * pow(sin(w * v), 2))
+                            return 2 * w * cosh(aa * u) * (-(w * cos(v) * cos(w * v)) - (sin(v) * sin(w * v))) / denom;
+                        },
+                        z: function (u, v) {
+                            var denom = aa * (pow(w * cosh(aa * u), 2) + aa * pow(sin(w * v), 2))
+                            return  2 * w * cosh(aa * u) * (-(w * sin(v) * cos(w * v)) + (cos(v) * sin(w * v))) / denom
+                        }
+                    };
+                }
+
+                chart.setOption({
+                    toolbox: {
+                        feature: {
+                            saveAsImage: {
+                                backgroundColor: '#111'
+                            }
+                        },
+                        iconStyle: {
+                            normal: {
+                                borderColor: '#fff'
+                            }
+                        },
+                        left: 0
+                    },
+                    xAxis3D: {
+                        type: 'value'
+                    },
+                    yAxis3D: {
+                        type: 'value'
+                    },
+                    zAxis3D: {
+                        type: 'value'
+                    },
+                    grid3D: {
+
+                        environment: 'none',
+
+                        axisPointer: {
+                            show: false
+                        },
+                        axisLine: {
+                            lineStyle: {
+                                color: '#fff'
+                            }
+                        },
+                        postEffect: {
+                            enable: true,
+                            screenSpaceAmbientOcclusion: {
+                                enable: true,
+                                radius: 4,
+                                intensity: 2
+                            }
+                        },
+                        temporalSuperSampling: {
+                            enable: true
+                        },
+                        light: {
+                            main: {
+                                intensity: 0
+                            },
+                            ambient: {
+                                intensity: 0
+                            },
+                            ambientCubemap: {
+                                texture: 'asset/pisa.hdr',
+                                exposure: 1,
+                                diffuseIntensity: 1,
+                                specularIntensity: 2
+                            }
+                        },
+                        viewControl: {
+                            // projection: 'orthographic'
+                        }
+                    },
+                    series: [{
+                        type: 'surface',
+                        parametric: true,
+                        shading: 'realistic',
+                        silent: true,
+                        wireframe: {
+                            show: false
+                        },
+                        realisticMaterial: {
+                            roughness: 0.3,
+                            metalness: 1
+                        },
+                        itemStyle: {
+                            color: '#aaa'
+                        },
+                        parametricEquation: getParametricEquation()
+                    }]
+                });
+
+                return chart;
+            }
+
+
+
+            var divs = []
+            var plots = []
+            function add_plot(constructor) {
+                var div = document.createElement('div');
+                div.style.width = '400px';
+                div.style.height = '400px';
+                div.style.float = 'left';
+                document.getElementById('plots').appendChild(div);
+                divs.push(div);
+                plots.push(constructor(div));
+            }
+
+            function resize_plots() {
+                var width = document.getElementById('width').value;
+                var height = document.getElementById('height').value;
+                for (var i = 0; i < divs.length; i++) {
+                    divs[i].style.width = width + 'px';
+                    divs[i].style.height = height + 'px';
+                    plots[i].resize(width, height);
+                }
+            }
+
+
+
+            add_plot(create_flow_plot);
+            add_plot(create_metal_plot);
+            add_plot(create_surface_plot);
+            add_plot(create_scatter_plot);
+            add_plot(create_flow_plot);
+            add_plot(create_metal_plot);
+
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
This largely fixes issues with lost WebGL contexts by sharing a single renderer for all plots and layers and recreating the renderer when the context is still lost.

Before, GL layers were completely lost and broke interactivity of plots when the context was lost. Now layers will stay as they were and the context is recreated on the next render. User should notice at most a glitch if the rerendering is heavy or there is some animation.

Main open issue left is that some 3D plots will lose textures/effects when the context is lost (typically after the next rerender). For example, test/surface-metal.html show this. To see, use test/multi.html, trigger losing of context and interact with the 'metal' plot.