### PR TITLE
fix: check for `eachOtherLayer` before invoke

### DIFF
--- a/src/echarts-gl.js
+++ b/src/echarts-gl.js
@@ -173,11 +173,13 @@ echarts.registerPostInit(function (chart) {
     var oldDispose = zr.painter.dispose;
 
     zr.painter.dispose = function () {
-        this.eachOtherLayer(function (layer) {
-            if (layer instanceof LayerGL) {
-                layer.dispose();
-            }
-        });
+        if (typeof this.eachOtherLayer === 'function') {
+            this.eachOtherLayer(function (layer) {
+                if (layer instanceof LayerGL) {
+                    layer.dispose();
+                }
+            });
+        }
         oldDispose.call(this);
     }
     zr.painter.getRenderedCanvas = function (opts) {


### PR DESCRIPTION
The change introduced [here](https://github.com/ecomfe/echarts-gl/commit/26f9e53ed3b795ad760b06602a0273e7a8200aea#diff-2a0b5e6212843be1cf0e6a75a9800f5640dc11c6b3e43470bdce312829c5dfc9R176) is only for `CanvasPainter`, yet it is being applied also to the `SVGPainter`, but only the canvas one has `eachOtherLayer` function defined, so the current code will throw an exception for the svg.

This mitigates this issue by checking that the `eachOtherLayer` function actually exists before trying to invoke it.

Fixes #438