### PR TITLE
修复首次 hover 到 dataIndex = 0 的区块不会高亮 + 移动端点击 series 无效的问题

### DIFF
--- a/src/component/common/Geo3DBuilder.js
+++ b/src/component/common/Geo3DBuilder.js
@@ -132,7 +132,7 @@ Geo3DBuilder.prototype = {
         this._updateDebugWireframe(componentModel);
 
         // Reset some state.
-        this._lastHoverDataIndex = 0;
+        this._lastHoverDataIndex = -1;
     },
 
     _initMeshes: function () {


### PR DESCRIPTION
## 首次 hover 到 dataIndex = 0 的区块不会高亮
- 问题分析：_lastHoverDataIndex 默认值为 0，代表初始 hover 区域为 dataIndex = 0 的区块，在 mouseover 逻辑中前后 dataIndex 相等不会执行高亮处理
- 解决方法：从 _lastHoverDataIndex 的定义上来看，默认状态应该为 -1， 代表 hover 区域为空，这也和 mouseout 中的操作一致
https://github.com/ecomfe/echarts-gl/blob/031da0ece1c0c7aeef1bd9a7d83672b1e9ac3b40/src/component/common/Geo3DBuilder.js#L359-L364

Closes #520

## 修复移动端点击 series 无效问题

- 问题分析：在移动端点击 series 区域不会触发 click 事件，由于 viewGL.dataIndex 依赖 mousemove 更新，而移动端没有mousemove 的步骤，因此点击时拿不到 viewGL.dataIndex，也就无法确定点击区域
- 解决方法：在 mousedown 时更新 viewGL.dataIndex


