### PR TITLE
修复问题：首次 hover 到 dataIndex = 0 的区块不会高亮

### DIFF
--- a/src/component/common/Geo3DBuilder.js
+++ b/src/component/common/Geo3DBuilder.js
@@ -132,7 +132,7 @@ Geo3DBuilder.prototype = {
         this._updateDebugWireframe(componentModel);
 
         // Reset some state.
-        this._lastHoverDataIndex = 0;
+        this._lastHoverDataIndex = -1;
     },
 
     _initMeshes: function () {


### PR DESCRIPTION
- **问题描述**：首次 hover 到 dataIndex = 0 的区块不会高亮
- **问题分析**：_lastHoverDataIndex 默认值为 0，代表初始 hover 区域为 dataIndex = 0 的区块，在 mouseover 逻辑中前后 dataIndex 相等不会执行高亮处理
- **解决方法**：从 _lastHoverDataIndex 的定义上来看，默认状态应该为 -1， 代表 hover 区域为空，这也和 mouseout 中的操作一致
https://github.com/ecomfe/echarts-gl/blob/031da0ece1c0c7aeef1bd9a7d83672b1e9ac3b40/src/component/common/Geo3DBuilder.js#L359-L364

Closes #520