### PR TITLE
修复移动端点击 series 无效的问题

### DIFF
--- a/src/component/common/Geo3DBuilder.js
+++ b/src/component/common/Geo3DBuilder.js
@@ -319,6 +319,7 @@ Geo3DBuilder.prototype = {
 
         polygonMesh.on('mousemove', this._onmousemove, this);
         polygonMesh.on('mouseout', this._onmouseout, this);
+        polygonMesh.on('mousedown', this._onmousedown, this);
     },
 
     _updateDebugWireframe: function (componentModel) {
@@ -340,6 +341,15 @@ Geo3DBuilder.prototype = {
             mesh.material.set('wireframeLineColor', color);
             mesh.material.set('wireframeLineWidth', width);
         }
+    },
+
+    _onmousedown: function (e) {
+        var dataIndex = this._dataIndexOfVertex[e.triangle[0]];
+        if (dataIndex == null) {
+            dataIndex = -1;
+        }
+        this._lastHoverDataIndex = dataIndex;
+        this._polygonMesh.dataIndex = dataIndex;
     },
 
     _onmousemove: function (e) {


### PR DESCRIPTION
- **问题分析**：在移动端点击 series 区域不会触发 click 事件，由于 viewGL.dataIndex 依赖 mousemove 更新，而移动端没有mousemove 的步骤，因此点击时拿不到 viewGL.dataIndex，也就无法确定点击区域
- **解决方法**：在 mousedown 时更新 viewGL.dataIndex