### PR TITLE
Drop gallery from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ ECharts-GL is an extension pack of [Apache ECharts](http://echarts.apache.org/),
 
 + [Option Manual](https://echarts.apache.org/zh/option-gl.html)
 
-+ [Gallery](https://www.makeapie.com/explore.html#tags=echarts-gl)
-
 ## Installing
 
 ###  npm and webpack


### PR DESCRIPTION
The gallery link is not working anymore: the user lands on a scam website.