### PR TITLE
Compat ec 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "dependencies": {
     "claygl": "^1.2.1",
-    "zrender": "^6.0.0"
+    "zrender": "^5.1.1 || ^6.0.0"
   },
   "peerDependencies": {
-    "echarts": "^6.0.0"
+    "echarts": "^5.1.2 || ^6.0.0"
   },
   "main": "dist/echarts-gl.js",
   "module": "index.js",
@@ -41,7 +41,7 @@
     "babel-plugin-module-resolver": "^4.1.0",
     "benchmark": "^2.1.3",
     "case-sensitive-paths-webpack-plugin": "^2.1.1",
-    "echarts": "^6.0.0",
+    "echarts": "^5.1.2 || ^6.0.0",
     "fs-extra": "^4.0.2",
     "glob": "^7.1.1",
     "http-server": "^0.10.0",

--- a/src/chart/line3D/Line3DView.js
+++ b/src/chart/line3D/Line3DView.js
@@ -172,7 +172,17 @@ export default echarts.ChartView.extend({
         lineMesh.off('mouseout');
         lineMesh.on('mousemove', function (e) {
             var value = coordSys.pointToData(e.point.array);
-            var dataIndex = seriesModel.indicesOfNearest('x', 'x', value[0])[0];
+
+            // Method `indicesOfNearest` was moved from `SeriesData` to `SeriesModel` since echarts@6.0.0.
+            var dataIndex;
+            if (seriesModel.indicesOfNearest) {
+                dataIndex = seriesModel.indicesOfNearest('x', 'x', value[0])[0];
+            }
+            else {
+                // For backward compatible with echarts@5.6.0 and earlier.
+                dataIndex = data.indicesOfNearest('x', value[0])[0];
+            }
+
             if (dataIndex !== lastDataIndex) {
                 // this._downplay(lastDataIndex);
                 // this._highlight(dataIndex);

--- a/src/component/geo3D/install.js
+++ b/src/component/geo3D/install.js
@@ -5,7 +5,14 @@ import Geo3DModel from './Geo3DModel';
 import Geo3DView from './Geo3DView';
 import geo3DCreator from '../../coord/geo3DCreator';
 
+var REGISTERED_TAG = '__ECGL_GEO3D_REGISTERED';
+
 export function install(registers) {
+    if (registers[REGISTERED_TAG]) {
+        return;
+    }
+    registers[REGISTERED_TAG] = true;
+
     registers.registerComponentModel(Geo3DModel);
     registers.registerComponentView(Geo3DView);
 

--- a/src/component/grid3D/Grid3DAxis.js
+++ b/src/component/grid3D/Grid3DAxis.js
@@ -113,7 +113,9 @@ Grid3DAxis.prototype.update = function (
         var labels = axis.getViewLabels();
 
         for (var i = 0; i < labels.length; i++) {
-            var tickValue = labels[i].tickValue;
+            var tickValue = echarts.util.isObject(labels[i].tick)
+                ? labels[i].tick.value // Since echarts@6.1.0 .
+                : labels[i].tickValue; // Otherwise, remain backward compatible.
             var formattedLabel = labels[i].formattedLabel;
             var rawLabel = labels[i].rawLabel;
 

--- a/src/util/EChartsSurface.js
+++ b/src/util/EChartsSurface.js
@@ -9,6 +9,7 @@
 import Texture2D from 'claygl/src/Texture2D';
 import Vector3 from 'claygl/src/math/Vector3';
 import Vector2 from 'claygl/src/math/Vector2';
+import {zrRefreshMonkeyPatch} from './compatHelper';
 
 var events = ['mousedown', 'mouseup', 'mousemove', 'mouseover', 'mouseout', 'click', 'dblclick', 'contextmenu'];
 
@@ -74,16 +75,10 @@ EChartsSurface.prototype = {
         }
         else {
             var self = this;
-            // Wrap refreshImmediately
-            var zr = chart.getZr();
-            var oldRefreshImmediately = zr.__oldRefreshImmediately || zr.refreshImmediately;
-            zr.refreshImmediately = function () {
-                oldRefreshImmediately.call(this);
+            zrRefreshMonkeyPatch(chart.getZr(), function () {
                 self._texture.dirty();
-
                 self.onupdate && self.onupdate();
-            };
-            zr.__oldRefreshImmediately = oldRefreshImmediately;
+            });
         }
 
         this._texture.image = canvas;

--- a/src/util/ZRTextureAtlasSurface.js
+++ b/src/util/ZRTextureAtlasSurface.js
@@ -7,6 +7,7 @@
 // TODO Expand.
 import * as echarts from 'echarts/lib/echarts';
 import Texture2D from 'claygl/src/Texture2D';
+import {zrRefreshMonkeyPatch} from './compatHelper';
 
 function ZRTextureAtlasSurfaceNode(zr, offsetX, offsetY, width, height, gap, dpr) {
     this._zr = zr;
@@ -193,12 +194,11 @@ function ZRTextureAtlasSurface (opt) {
      * @type {zrender~ZRender}
      */
     this._zr = echarts.zrender.init(canvas);
-    var oldRefreshImmediately = this._zr.refreshImmediately;
-    this._zr.refreshImmediately = function () {
-        oldRefreshImmediately.call(this);
+
+    zrRefreshMonkeyPatch(this._zr, function () {
         self._texture.dirty();
         self.onupdate && self.onupdate();
-    };
+    });
 
     this._dpr = opt.devicePixelRatio;
 

--- a/src/util/compatHelper.js
+++ b/src/util/compatHelper.js
@@ -1,14 +1,14 @@
 /**
- * Compatibility helpers for echarts 6.
- *
+ * Compatibility helpers for echarts and zrender.
+ */
+
+/**
  * In echarts 6, DataStore.initData unconditionally calls provider.getSource()
  * on custom data providers. Custom providers that only define {count, getItem}
  * (without getSource) will throw "provider.getSource is not a function".
  *
  * This helper wraps such providers so they are compatible with echarts 6.
- */
-
-/**
+ *
  * Ensure data passed to SeriesData.initData is compatible with echarts 6.
  * If data is a custom provider object (has count/getItem but no getSource),
  * add the required getSource method.
@@ -40,4 +40,24 @@ export function ensureDataProvider(data) {
         }
     }
     return data;
+}
+
+/**
+ * NOTE: Keep this method idempotent.
+ */
+export function zrRefreshMonkeyPatch(zr, afterZrRealRefresh) {
+    if (zr.__ECGLOnRefresh) {
+        return;
+    }
+    zr.__ECGLOnRefresh = true;
+
+    // Since zrender@6.1.0, a immediate refresh is performed if and only if `zr._refresh` is called,
+    // and no `zr._refresh` method.
+    // Otherwise, in previous zrender, it is performed if and only if `zr.refreshImmediately` is called.
+    var patchedMethodName = zr._refresh ? '_refresh' : 'refreshImmediately';
+    var oldZrMethod = zr[patchedMethodName];
+    zr[patchedMethodName] = function () {
+        oldZrMethod.apply(this, arguments);
+        afterZrRealRefresh();
+    };
 }

--- a/test/surface-dataShape2.html
+++ b/test/surface-dataShape2.html
@@ -18,24 +18,30 @@
             var data = [{"x_variable":3,"y_variable":2,"z_variable":0.11820376636125732},{"x_variable":3,"y_variable":2.2,"z_variable":0.11838565255805805},{"x_variable":3,"y_variable":2.4000000000000004,"z_variable":0.11849087154367917},{"x_variable":3,"y_variable":2.6000000000000005,"z_variable":0.11856097826096688},{"x_variable":3,"y_variable":2.8000000000000007,"z_variable":0.11861062848581362},{"x_variable":3,"y_variable":3.000000000000001,"z_variable":0.11863864806404903},{"x_variable":3.4,"y_variable":2,"z_variable":0.13377022622069884},{"x_variable":3.4,"y_variable":2.2,"z_variable":0.13397853325385709},{"x_variable":3.4,"y_variable":2.4000000000000004,"z_variable":0.13411038558980926},{"x_variable":3.4,"y_variable":2.6000000000000005,"z_variable":0.13418064159074816},{"x_variable":3.4,"y_variable":2.8000000000000007,"z_variable":0.1342238601228674},{"x_variable":3.4,"y_variable":3.000000000000001,"z_variable":0.13425779324265025},{"x_variable":3.8,"y_variable":2,"z_variable":0.14926887220012097},{"x_variable":3.8,"y_variable":2.2,"z_variable":0.14950972399165724},{"x_variable":3.8,"y_variable":2.4000000000000004,"z_variable":0.14964649746639389},{"x_variable":3.8,"y_variable":2.6000000000000005,"z_variable":0.14973742666916345},{"x_variable":3.8,"y_variable":2.8000000000000007,"z_variable":0.14979642579056768},{"x_variable":3.8,"y_variable":3.000000000000001,"z_variable":0.14982737479501065},{"x_variable":4.2,"y_variable":2,"z_variable":0.16468827776834613},{"x_variable":4.2,"y_variable":2.2,"z_variable":0.16495908998206169},{"x_variable":4.2,"y_variable":2.4000000000000004,"z_variable":0.1651285026210502},{"x_variable":4.2,"y_variable":2.6000000000000005,"z_variable":0.1652300797226232},{"x_variable":4.2,"y_variable":2.8000000000000007,"z_variable":0.16529287316961533},{"x_variable":4.2,"y_variable":3.000000000000001,"z_variable":0.16533212505061454},{"x_variable":4.6000000000000005,"y_variable":2,"z_variable":0.18000802139974567},{"x_variable":4.6000000000000005,"y_variable":2.2,"z_variable":0.18031868758822447},{"x_variable":4.6000000000000005,"y_variable":2.4000000000000004,"z_variable":0.18051245398818438},{"x_variable":4.6000000000000005,"y_variable":2.6000000000000005,"z_variable":0.18062747043505945},{"x_variable":4.6000000000000005,"y_variable":2.8000000000000007,"z_variable":0.18070728844739262},{"x_variable":4.6000000000000005,"y_variable":3.000000000000001,"z_variable":0.18075122463922141},{"x_variable":5.000000000000001,"y_variable":2,"z_variable":0.19524493430393514},{"x_variable":5.000000000000001,"y_variable":2.2,"z_variable":0.1955868671669967},{"x_variable":5.000000000000001,"y_variable":2.4000000000000004,"z_variable":0.19583236633177153},{"x_variable":5.000000000000001,"y_variable":2.6000000000000005,"z_variable":0.19594125476043558},{"x_variable":5.000000000000001,"y_variable":2.8000000000000007,"z_variable":0.19602239756102846},{"x_variable":5.000000000000001,"y_variable":3.000000000000001,"z_variable":0.19607731791873192}];
             var parsedData = data.map((d) => [d.x_variable, d.y_variable, d.z_variable])
 
+            function min(list, idx) {
+                return list.reduce((result, d) => Math.min(d[idx], result), Infinity)
+            }
+            function max(list, idx) {
+                return list.reduce((result, d) => Math.max(d[idx], result), -Infinity)
+            }
 
             chart.setOption(option = {
                 tooltip: {},
                 backgroundColor: '#fff',
                 xAxis3D: {
                     type: 'value',
-                    min: Math.min(parsedData.map((d) => d[0])),
-                    max: Math.max(parsedData.map((d) => d[0]))
+                    min: min(parsedData, 0),
+                    max: max(parsedData, 0),
                 },
                 yAxis3D: {
                     type: 'value',
-                    min: Math.min(parsedData.map((d) => d[1])),
-                    max: Math.max(parsedData.map((d) => d[1]))
+                    min: min(parsedData, 1),
+                    max: max(parsedData, 1),
                 },
                 zAxis3D: {
                     type: 'value',
-                    min: Math.min(parsedData.map((d) => d[2])),
-                    max: Math.max(parsedData.map((d) => d[2]))
+                    min: min(parsedData, 2),
+                    max: max(parsedData, 2),
                 },
                 grid3D: {
                 },


### PR DESCRIPTION
Support `echarts@6.1.0` and `zrender@6.1.0`.

+ Compat: Cartesian 3d axis does not work due to breaking changes introduced by echarts@6.1.0 zrender@6.1.0. Add compatiblity code to support both new and old versions of echarts and zrender. Before this fix, `test/line3D.html` do not display `axisLabel` and `axisPointer`.
+ Fix: geo3d should not be duplicated registered, otherwise a warning is always reported (like `geo3d exists`).
+ Fix: #561 has upgraded dep echarts and zrender version to 6.0.0, but no need to force users to upgrade echarts and zrender. So add back the original versions as `^6.0.0 || ^5.1.2`.
+ Fix: Fix incorrect test case - it coincidentally works before echarts@6.1.0 but it does not work by echarts@6.1.0 breaking change (axis.min/max: NaN is not ignored since echarts@6.1.0).
